### PR TITLE
add support for passing in a SAS token

### DIFF
--- a/lib/fluent/plugin/azureeventhubs/http.rb
+++ b/lib/fluent/plugin/azureeventhubs/http.rb
@@ -1,6 +1,6 @@
 
 class AzureEventHubsHttpSender
-  def initialize(connection_string,hub_name,expiry=3600,proxy_addr='',proxy_port=3128,open_timeout=60,read_timeout=60)
+  def initialize(connection_string,hub_name,uri,secure_access_signature,sas_expiration,secure_access_policy_name,expiry=3600,proxy_addr='',proxy_port=3128,open_timeout=60,read_timeout=60)
     require 'openssl'
     require 'base64'
     require 'net/http'
@@ -10,33 +10,46 @@ class AzureEventHubsHttpSender
     require 'httpclient'
     @connection_string = connection_string
     @hub_name = hub_name
+    @uri = uri
+    @secure_access_signature = secure_access_signature
+    @sas_expiration = sas_expiration
+    @secure_access_policy_name = secure_access_policy_name
     @expiry_interval = expiry
     @proxy_addr = proxy_addr
     @proxy_port = proxy_port
     @open_timeout = open_timeout
     @read_timeout = read_timeout
 
-    if @connection_string.count(';') > 3
-      raise "Connection String format is not correct"
+    valid_connection_string = lambda { [2,3].include?@connection_string.count(';') }
+    valid_sas = lambda { [@uri, @secure_access_signature, @secure_access_policy_name].all?{|x| x.length > 0} }
+
+    if !valid_connection_string.call and !valid_sas.call
+      raise "Valid connection_string or [uri, secure_access_signature, sas_expiration, secure_access_policy_name] must be provided"
     end
 
-    @connection_string.split(';').each do |part|
-      if ( part.index('Endpoint') == 0 )
-        @endpoint = 'https' + part[11..-1]
-      elsif ( part.index('SharedAccessKeyName') == 0 )
-        @sas_key_name = part[20..-1]
-      elsif ( part.index('SharedAccessKey') == 0 )
-        @sas_key_value = part[16..-1]
-      elsif ( part.index('EntityPath') == 0 )
-        @hub_name = part[11..-1]
+    if valid_connection_string.call
+      @connection_string.split(';').each do |part|
+        if ( part.index('Endpoint') == 0 )
+          @endpoint = 'https' + part[11..-1]
+        elsif ( part.index('SharedAccessKeyName') == 0 )
+          @secure_access_policy_name = part[20..-1]
+        elsif ( part.index('SharedAccessKey') == 0 )
+          @sas_key_value = part[16..-1]
+        elsif ( part.index('EntityPath') == 0 )
+          @hub_name = part[11..-1]
+        end
       end
-    end
 
-    if [@endpoint, @sas_key_name, @sas_key_value, @hub_name].any?{|v| v == nil || v == "" }
-      raise "Connection String is missing required information"
-    end
+      if [@endpoint, @secure_access_policy_name, @sas_key_value, @hub_name].any?{|v| v == nil || v == "" }
+        raise "Connection String is missing required information"
+      end
 
-    @uri = URI.parse("#{@endpoint}#{@hub_name}/messages")
+      @uri = URI.parse("#{@endpoint}#{@hub_name}/messages")
+    
+    else #valid_sas
+      @uri = URI.parse(uri)
+      @token = generate_sas_auth_header(@uri.to_s, @secure_access_signature, @sas_expiration, @secure_access_policy_name)
+    end
 
     if (proxy_addr.to_s.empty?)
       @client = HTTPClient.new
@@ -46,33 +59,45 @@ class AzureEventHubsHttpSender
     end
   end
 
-  def generate_sas_token(uri)
-    target_uri = CGI.escape(uri.downcase).downcase
-    expiry = Time.now.to_i + @expiry_interval
-    to_sign = "#{target_uri}\n#{expiry}";
-    signature = CGI.escape(Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), @sas_key_value, to_sign)).strip())
-
-    token = "SharedAccessSignature sr=#{target_uri}&sig=#{signature}&se=#{expiry}&skn=#{@sas_key_name}"
+  def generate_sas_auth_header(target_uri, signature, expiry, key_name)
+    encoded_uri = CGI.escape(target_uri)
+    encoded_signature = CGI.escape(signature)
+    token = "SharedAccessSignature sr=#{encoded_uri}&sig=#{encoded_signature}&se=#{expiry}&skn=#{key_name}"
     return token
   end
 
-  private :generate_sas_token
+  def generate_secure_access_signature(uri, expiry_interval, key_value)
+    target_uri = CGI.escape(uri)
+    expiry = Time.now.to_i + expiry_interval
+    to_sign = "#{target_uri}\n#{expiry}";
+    signature = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key_value, to_sign)).strip()
+    return signature, expiry
+  end
+
+  private :generate_secure_access_signature
+  private :generate_sas_auth_header
 
   def send(payload)
     send_w_properties(payload, nil)
   end
 
   def send_w_properties(payload, properties)
-    token = generate_sas_token(@uri.to_s)
+    if @token.nil? || @sas_expiration < Time.now.to_i
+      @signature, @sas_expiration = generate_secure_access_signature(@uri.to_s, @expiry_interval, @sas_key_value)
+      @token = generate_sas_auth_header(@uri.to_s, @signature, @sas_expiration, @secure_access_policy_name)
+    end
+
     headers = {
       'Content-Type' => 'application/atom+xml;type=entry;charset=utf-8',
-      'Authorization' => token
+      'Authorization' => @token
     }
     if not properties.nil?
       headers = headers.merge(properties)
     end
     body = payload.to_json
     res = @client.post(@uri.to_s, body, headers)
-    rescue HTTPClient::TimeoutError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Errno::ETIMEDOUT, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+    if res.status >= 300
+      raise "Error while sending message, status=#{res.status}"
+    end
   end
 end

--- a/lib/fluent/plugin/out_azureeventhubs_buffered.rb
+++ b/lib/fluent/plugin/out_azureeventhubs_buffered.rb
@@ -7,8 +7,12 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    config_param :connection_string, :string
-    config_param :hub_name, :string
+    config_param :connection_string, :string, :default => ''
+    config_param :hub_name, :string, :default => ''
+    config_param :uri, :string, :default => ''
+    config_param :secure_access_signature, :string, :default => ''
+    config_param :sas_expiration, :integer, :default => 0
+    config_param :secure_access_policy_name, :string, :default => ''
     config_param :include_tag, :bool, :default => false
     config_param :include_time, :bool, :default => false
     config_param :tag_time_name, :string, :default => 'time'
@@ -36,7 +40,7 @@ module Fluent::Plugin
         raise NotImplementedError
       else
         require_relative 'azureeventhubs/http'
-        @sender = AzureEventHubsHttpSender.new(@connection_string, @hub_name, @expiry_interval,@proxy_addr,@proxy_port,@open_timeout,@read_timeout)
+        @sender = AzureEventHubsHttpSender.new(@connection_string, @hub_name, @uri, @secure_access_signature, @sas_expiration, @secure_access_policy_name, @expiry_interval,@proxy_addr,@proxy_port,@open_timeout,@read_timeout)
       end
       raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
     end


### PR DESCRIPTION
- passing in a SAS token rather than connection string is desirable for
  distributing authorization credentials that are shared without
  exposing the underlying credential
- remove rescue from http output and raise an exception if post
  operation fails, previously all errors were being silently
  dropped